### PR TITLE
Correct the node_modules path in the run react script

### DIFF
--- a/scripts/start/react.sh
+++ b/scripts/start/react.sh
@@ -53,7 +53,7 @@ start_react_server() {
         --env NAME=${NAME} \
         --env PROXY=${PROXY} \
         omniport-react:latest \
-        yarn --modules-folder /node_modules start --port ${PORT}
+        yarn --modules-folder ../node_modules start --port ${PORT}
 }
 
 if [[ ${DJANGO} -ne -1 ]]; then


### PR DESCRIPTION
Currently, the react container can not be run due to mispositioned node_modules folder. The build container script leaves the WORKDIR inside the folder `omniport` whereas the node_modules folder resides one step back. A possible solution is to use node_modules from a directory back i.e. `../` which is in this PR. One more solution can be installing node_modules in the `omniport` folder by changing the WORKDIR to omniport before installing the node_modules in the build react.sh script in omniport-docker.