### PR TITLE
Modify the conditions and routes to prevent the first time 404 on clicking on an app

### DIFF
--- a/omniport/core/App.js
+++ b/omniport/core/App.js
@@ -24,6 +24,12 @@ class App extends Component {
     this.props.setAppList()
   }
 
+  componentDidUpdate (prev) {
+    if (this.props.isAuthenticated && this.props.appList.errored) {
+      this.props.setAppList()
+    }
+  }
+
   render () {
     const { appList, history } = this.props
     return (
@@ -78,19 +84,22 @@ class App extends Component {
               })}
 
             {/* Route to serve apps */}
-            {appList.isLoaded &&
-              appList.data.map((app, index) => {
-                return (
-                  <Route
-                    path={app.baseUrl}
-                    key={index}
-                    component={React.lazy(() => import(`apps/${app.source}`))}
-                  />
-                )
-              })}
+            {appList && appList.isLoaded && (
+              <Switch>
+                {appList.data.map((app, index) => {
+                  return (
+                    <Route
+                      path={app.baseUrl}
+                      key={index}
+                      component={React.lazy(() => import(`apps/${app.source}`))}
+                    />
+                  )
+                })}
 
-            {/* Default 404 page */}
-            {appList.isLoaded && <Route component={NoMatch} />}
+                {/* Default 404 page */}
+                <Route component={NoMatch} />
+              </Switch>
+            )}
           </Switch>
         </Router>
       </Suspense>
@@ -100,7 +109,8 @@ class App extends Component {
 
 const mapStateToProps = state => {
   return {
-    appList: state.appList
+    appList: state.appList,
+    isAuthenticated: state.user.isAuthenticated
   }
 }
 

--- a/omniport/core/common/src/actions/appList.js
+++ b/omniport/core/common/src/actions/appList.js
@@ -1,29 +1,37 @@
 import axios from 'axios'
 
-import { commonApps } from 'formula_one'
-import { urlAppList } from 'formula_one'
+import { commonApps, urlAppList, urlWhoAmI } from 'formula_one'
 
 export const setAppList = () => {
   return dispatch => {
     axios
-      .get(urlAppList())
-      .then(res => {
-        dispatch({
-          type: 'SET_APPLIST',
-          payload: {
-            isLoaded: true,
-            data: commonApps(res.data)
-          }
-        })
-      })
-      .catch(err => {
-        dispatch({
-          type: 'SET_APPLIST',
-          payload: {
-            isLoaded: true,
-            data: []
-          }
-        })
+      .get(urlWhoAmI())
+      .then()
+      .finally(() => {
+        axios
+          .get(urlAppList())
+          .then(res => {
+            console.log(res)
+            dispatch({
+              type: 'SET_APPLIST',
+              payload: {
+                isLoaded: true,
+                errored: false,
+                data: commonApps(res.data)
+              }
+            })
+          })
+          .catch(err => {
+            console.log(err)
+            dispatch({
+              type: 'SET_APPLIST',
+              payload: {
+                isLoaded: true,
+                errored: true,
+                data: []
+              }
+            })
+          })
       })
   }
 }

--- a/omniport/core/common/src/reducers/appList.js
+++ b/omniport/core/common/src/reducers/appList.js
@@ -1,5 +1,6 @@
 const initialState = {
   isLoaded: false,
+  errored: false,
   data: []
 }
 


### PR DESCRIPTION
There was a problem in the code. When user login and click on an app, first time it renders a 404 page i.e. the default route from the `App.js` file. On keen investigation, I found that the `appList` API was called before the user is authenticated. So, the conditions are changed accordingly to overcome this issue.