### PR TITLE
Change conditions for fetching AppList

### DIFF
--- a/omniport/core/App.js
+++ b/omniport/core/App.js
@@ -26,8 +26,13 @@ class App extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    if (this.props.isAuthenticated !== prevProps.isAuthenticated &&
-        this.props.appList.errored !== prevProps.appList.errored) {
+    /* Update appList when 
+       1. Authentication changes
+       2. A person is authenticated and appList is errored
+    */
+    if (this.props.isAuthenticated !== prevProps.isAuthenticated ||
+        (this.props.isAuthenticated === true && this.props.appList.errored === true)
+      ) {
       this.props.setAppList()
     }
   }


### PR DESCRIPTION
Issue:

The previous condition for fetching appList caused 404 when entering in apps for the first time,
because the appList was not updated when state.isAuthenticated changes independent of 
isErrored of this.state.appList.errored, thus resulting in the  routes not being added.

The change ensures the appList is updated whenever <br/>
 1. authentication state changes. (this makes sure we update whenever user logs in or out )
 2. Whenever user is authenticated and appList has an error ( for the independent case )