### PR TITLE
Add option to allow public routes for some apps if needed

### DIFF
--- a/omniport/core/App.js
+++ b/omniport/core/App.js
@@ -93,6 +93,23 @@ class App extends Component {
                 )
               })}
 
+            {/* Route to serve public face of an app if exists */}
+            {configs.apps
+              .filter(app => {
+                return app.public
+              })
+              .map((app, index) => {
+                return (
+                  <Route
+                    path={`/public${app.public.baseUrl}`}
+                    key={index}
+                    component={React.lazy(() =>
+                      import(`apps/${app.public.source}`)
+                    )}
+                  />
+                )
+              })}
+
             {/* Route to serve apps */}
             {appList && appList.isLoaded && (
               <Switch>


### PR DESCRIPTION
Sample App `config.json`

```json
{
    "nomenclature": {
        "name": "test",
        "verboseName": "Test"
    },
    "baseUrl": "/test",
    "source": "test/src/index",
    "public": {
        "source": "test/src/public",
        "baseUrl": "/test"
    }
}
```

Keep `public.js` file similar to `index.js` file. This `public.js` file will be a new gateway to your app which will open at `/public/${app.public.baseUrl}` .
