### PR TITLE
Proxy the route external to the backend server in development mode

### DIFF
--- a/omniport/config/webpack.dev.js
+++ b/omniport/config/webpack.dev.js
@@ -36,6 +36,7 @@ module.exports = merge(common, {
 
         // Files
         '/branding',
+        '/external',
         '/static',
         '/media',
         '/personal',


### PR DESCRIPTION
Please refer https://github.com/IMGIITRoorkee/omniport-docker/pull/34 with this PR. This allows the /external route to be served in the development mode.